### PR TITLE
add support for specifying plugin configuration file name

### DIFF
--- a/tasks/collectd.conf.yml
+++ b/tasks/collectd.conf.yml
@@ -13,7 +13,7 @@
 - name: ensure collectd plugins
   template:
     src: "collectd.plugin.j2"
-    dest: "{{ collectd_conf_include_dir }}/{{ item.name }}.conf"
+    dest: "{{ collectd_conf_include_dir }}/{{ item.file_name | default(item.name) }}.conf"
     owner: "{{ collectd_user }}"
     group: "{{ collectd_group }}"
     mode: 0644


### PR DESCRIPTION
it is supposed to use 'file_name' key (per plugin definition).
value will be the specified configuration file name + .conf extension