### PR TITLE
remove prometheus file sd dependency and logic

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,6 +31,3 @@ collectd_hostname: "{{ inventory_hostname }}"
 collectd_fqdnlookup: false
 
 collectd_plugins: []
-collectd_prometheus_file_sd: false
-collectd_prometheus_file_sd_target_name: "collectd"
-collectd_prometheus_file_sd_target_port: 9103

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,4 +17,3 @@ galaxy_info:
         - "buster"
 dependencies:
   - role: "damex.package"
-  - role: "damex.prometheus_file_sd"

--- a/tasks/file_sd.yml
+++ b/tasks/file_sd.yml
@@ -1,9 +1,0 @@
----
-- name: ensure prometheus file sd
-  include_role:
-    name: "damex.prometheus_file_sd"
-  vars:
-    prometheus_file_sd_target_name: |-
-      {{ collectd_prometheus_file_sd_target_name }}
-    prometheus_file_sd_target_port: |-
-      {{ collectd_prometheus_file_sd_target_port }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,5 @@
     - import_tasks: directories.yml
     - import_tasks: collectd.conf.yml
     - import_tasks: systemd.yml
-    - import_tasks: file_sd.yml
-      when: collectd_prometheus_file_sd
   tags:
     - collectd


### PR DESCRIPTION
it should not be a part of this role since people might use
something else instead of prometheus file sd and it is tied to
just only one collectd plugin